### PR TITLE
Add support for custom icons/images

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Currently, the following components are provided:
 ## Roadmap
 
 * Add support of [C4](https://diagrams.mingrammer.com/docs/nodes/c4).
-* Add support of [Custom](https://diagrams.mingrammer.com/docs/nodes/custom).
 * Add IDEs plugins and/or web user interface for live editing.
 * Add the `JSON Schema` to [Json Schema Store](https://github.com/fox-forks/schemastore).
 * Research Confluence integration to update images from the CI-builds directly.
@@ -363,6 +362,7 @@ Basically, to recap and also clarify:
 | `id`      | String | Yes      | -                                                                                                   | -       | A unique identifier of the resource.     |
 | `name`    | String | Yes      | -                                                                                                   | -       | A name of the resource.                  |
 | `type`    | String | Yes      | One of the [those](https://github.com/dmytrostriletskyi/diagrams-as-code/tree/main/docs/resources). | -       | A type of the resource.                  |
+| `src`     | String | No       | When `type` is set to `custom` this will provide the source of the custom icon/image                | -       | A path to a custom icon/image.           |
 | `relates` | Object | No       | -                                                                                                   | -       | A relationship to a resource or a group. |
 
 This is the table of all available types by a category:

--- a/diagrams_as_code/enums.py
+++ b/diagrams_as_code/enums.py
@@ -11,6 +11,7 @@ class ServiceResourceType(Enum):
 
     CLUSTER = 'cluster'
     GROUP = 'group'
+    CUSTOM = 'custom'
 
 
 class RelationDirection(str, Enum):

--- a/diagrams_as_code/schema.py
+++ b/diagrams_as_code/schema.py
@@ -50,6 +50,7 @@ class YamlDiagramResource(BaseModel):
     type: str
     of: list[YamlDiagramResource] | None = []
     relates: list[YamlDiagramResourceRelationship] | None = []
+    src: str | None = None
 
 
 class YamlDiagramResourceRelationship(BaseModel):


### PR DESCRIPTION
Add support for custom icons/images.  I'm not much of a Python dev but I really wanted custom icons in my infra diagrams so here I am with a PR. I feel good about it except the relationships part.  I copypasta'd that and I'm unsure if it's bug-free.  I was able to gen output and see my custom icon, which felt like success to me.

Usage
```yaml
type: custom
src: some/path/to/image.png
name: Some custom thing
```